### PR TITLE
Add login and signup page

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -62,8 +62,7 @@ def login():
     if current_user.is_authenticated:
         return redirect(url_for('root'))
 
-    form = LoginForm()
-    signupform = SignupForm()
+    form = LoginForm(request.form)
     if form.validate_on_submit():
         log.info('valid form')
         email = form.email.data

--- a/main.py
+++ b/main.py
@@ -132,11 +132,6 @@ def handle_listings():
             abort(500, "Failed to get listings")
         return jsonify(listings)
 
-@app.route('/profile')
-@login_required
-def profile():
-    return render_template('profile.html', name=current_user.name)
-
 @login_manager.user_loader
 def load_user(user_id):
     ''' 

--- a/templates/login.html
+++ b/templates/login.html
@@ -116,7 +116,7 @@ http://www.templatemo.com/tm-500-fluid-gallery
                                 <div class="tm-flex tm-contact-container">  
                                     <div class="tm-bg-white-translucent text-xs-left tm-textbox tm-2-col-textbox-2 tm-textbox-padding tm-textbox-padding-contact">
                                         <h2 class="tm-contact-info">Log In</h2>
-                                                <form action="/login" method="POST" enctype="multipart/form-data" style="box-shadow: none;">
+                                                <form action="/login" method="POST" style="box-shadow: none;">
                                                     {{ loginform.hidden_tag() }}
 
                                                     <div class="item">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,3 +1,0 @@
-<h1 class="title">
-    Welcome, {{ name }}!
-  </h1>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -116,7 +116,7 @@ http://www.templatemo.com/tm-500-fluid-gallery
                                 <div class="tm-flex tm-contact-container">  
                                     <div class="tm-bg-white-translucent text-xs-left tm-textbox tm-2-col-textbox-2 tm-textbox-padding tm-textbox-padding-contact">
                                         <h2 class="tm-contact-info">Sign Up</h2>
-                                                <form action="/signup" method="POST" enctype="multipart/form-data" style="box-shadow: none;">
+                                                <form action="/signup" method="POST" style="box-shadow: none;">
                                                     {{ form.hidden_tag() }}
 
                                                     <div class="item">

--- a/templates/verify.html
+++ b/templates/verify.html
@@ -92,7 +92,7 @@ http://www.templatemo.com/tm-500-fluid-gallery
                                     <div class="tm-flex tm-contact-container">  
                                         <div class="tm-bg-white-translucent text-xs-left tm-textbox tm-2-col-textbox-2 tm-textbox-padding tm-textbox-padding-contact">
                                             <h2 class="tm-contact-info">Resend Verification Link</h2>
-                                                    <form action="/login" method="POST" enctype="multipart/form-data" style="box-shadow: none;">
+                                                    <form action="/login" method="POST" style="box-shadow: none;">
                                                         {{ form.hidden_tag() }}
 
                                                         <div class="item">


### PR DESCRIPTION
Added login and signup page
The links in the nav bar will change to once user has been logged in

Current issues: I can't figure out how to redirect to certain "tab" in the navbar. So currently after failed login and signup, it will redirect to root - which is the cat page. This doesn't disrupt the functionality but is super inconvenient for the users. If anyone knows how to fix this, that would be great!

Also added tab in navbar for profile (for user profile and user listings) - yet to be implemented